### PR TITLE
redesign keep to do only clone in the structured path

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,29 +1,11 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"flag"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 )
-
-var Usage string = `
-Keep downloads and organizes repositories.
-
-Usage:
-
-	keep [arguments] <repository>
-`
-
-type githubContent struct {
-	organization string
-}
 
 // die prints error then exit.
 func die(err interface{}) {
@@ -32,14 +14,9 @@ func die(err interface{}) {
 }
 
 func main() {
-	var fork bool
-	flag.BoolVar(&fork, "fork", false, "create a fork of the repo, then download the fork")
-	flag.Parse()
-	args := flag.Args()
+	args := os.Args[1:]
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, Usage)
-		flag.PrintDefaults()
-		os.Exit(1)
+		die("clone address not specified")
 	}
 	addr := args[0]
 	if strings.Contains(addr, "://") {
@@ -53,58 +30,9 @@ func main() {
 	path := hostPath[1]
 	switch host {
 	case "github.com":
-		user := os.Getenv("KEEP_GITHUB_USER")
-		token := os.Getenv("KEEP_GITHUB_AUTH")
-		if fork {
-			if user == "" {
-				die("KEEP_GITHUB_USER should be specified to fork")
-			}
-			if token == "" {
-				die("KEEP_GITHUB_AUTH should be specified to fork")
-			}
-		}
-
 		paths := strings.Split(path, "/")
 		if len(paths) != 2 {
 			die("invalid repository path:" + path)
-		}
-		org := paths[0]
-		repo := paths[1]
-
-		upstream := ""
-		origin := addr
-		if fork {
-			upstream = addr
-			origin = host + "/" + user + "/" + repo
-		}
-
-		if fork {
-			// request a fork of the repo
-			forkApiAddr := fmt.Sprintf("https://api.github.com/repos/%s/%s/forks", org, repo)
-			content, err := json.Marshal(githubContent{organization: user})
-			if err != nil {
-				die(fmt.Errorf("unable to marshal githubContent: %w", err))
-			}
-			req, err := http.NewRequest("POST", forkApiAddr, bytes.NewBuffer(content))
-			if err != nil {
-				die(err)
-			}
-			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("Accept", "application/vnd.github.v3+json")
-			req.Header.Add("Authorization", "token "+token)
-
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				die(err)
-			}
-			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				die(fmt.Errorf("could not read response body: %w", err))
-			}
-			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-				die(fmt.Sprintf("bad response status: %d\n%s", resp.StatusCode, string(body)))
-			}
 		}
 
 		keepPath := os.Getenv("KEEPPATH")
@@ -117,23 +45,18 @@ func main() {
 		}
 		dst := keepPath + "/" + addr
 		_, err := os.Stat(dst)
-		if err != nil && !os.IsNotExist(err) {
-			die(err)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				die(err)
+			}
 		} else if err == nil {
 			die(fmt.Sprintf("dest directory already exists: %s", dst))
 		}
-		dstParent := filepath.Dir(dst)
-		err = os.MkdirAll(dstParent, 0755)
+		err = os.MkdirAll(dst, 0755)
 		if err != nil {
 			die(fmt.Errorf("could not make intermediate directories: %w", err))
 		}
-		cloneAddr := origin
-		if token != "" {
-			cloneAddr = token + "@" + cloneAddr
-		} else if user != "" {
-			cloneAddr = user + "@" + cloneAddr
-		}
-		cmd := exec.Command("git", "clone", "https://"+cloneAddr, dst)
+		cmd := exec.Command("git", "clone", "https://"+addr, dst)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -141,21 +64,21 @@ func main() {
 		if err != nil {
 			die(err)
 		}
-		if upstream != "" {
-			if token != "" {
-				upstream = token + "@" + upstream
-			} else if user != "" {
-				upstream = user + "@" + upstream
-			}
-			cmd = exec.Command("git", "remote", "add", "upstream", "https://"+upstream)
-			cmd.Dir = dst
-			out, err := cmd.CombinedOutput()
-			if err != nil {
-				die(fmt.Sprintf("%s\n%s", string(out), err))
-			}
+
+		// you don't need permission for 'origin' except some specific times.
+		// when you need it, use remote 'origin-private' instead.
+		// which is actually 'origin' with the authentication token.
+		token := os.Getenv("KEEP_GITHUB_AUTH")
+		if token == "" {
+			return
+		}
+		cmd = exec.Command("git", "-C", dst, "remote", "add", "origin-private", "https://"+token+"@"+addr)
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprint(os.Stderr, string(b))
+			die(err)
 		}
 	default:
 		die(fmt.Sprintf("unsupported host: %s", host))
 	}
-
 }


### PR DESCRIPTION
keep에서 fork 기능을 삭제했습니다.

또 origin과 origin-private을 분리시켜서 필요시에만 origin에 대한 권한을 가질수 있도록 재설계했습니다. 제가 kalena에 한 짓을 반복하지 않도록요.